### PR TITLE
docs: add governance model

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,1 @@
+This repository is part of the KubeFleet project, a CNCF sandbox project. See the [KubeFleet Governance Model](https://github.com/kubefleet-dev/kubefleet/blob/main/GOVERNANCE.md) for more information.


### PR DESCRIPTION
This PR adds the governance model file to the repository (which refers to the same file under the main repository).