### PR TITLE
fix: address the permission issue in GitHub Pages build/deploy pipeline

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     # The latest tag of the Ubuntu image points to the latest LTS version of Ubuntu, as specified on the Docker Hub.


### PR DESCRIPTION
This PR addresses a permission issue in the existing GitHub Pages build/deploy pipeline.