### PR TITLE
fix: apply header setup for some troubleshooting docs

### DIFF
--- a/content/en/docs/troubleshooting/ClusterResourcePlacementEviction.md
+++ b/content/en/docs/troubleshooting/ClusterResourcePlacementEviction.md
@@ -1,4 +1,8 @@
-# Placement Eviction & Placement Disruption Budget Troubleshooting Guide
+---
+title: How to Troubleshoot Eviction Related Issues
+description: Identify and fix KubeFleet issues associated with the the Eviction API
+weight: 1
+---
 
 This guide provides troubleshooting steps for issues related to placement eviction.
 

--- a/content/en/docs/troubleshooting/_index.md
+++ b/content/en/docs/troubleshooting/_index.md
@@ -1,0 +1,10 @@
+---
+title: Troubleshooting Guides
+description: Guides for identifying and fixing common KubeFleet issues
+weight: 5
+---
+
+{{% pageinfo %}}
+KubeFleet documentation features a number of troubleshooting guides to help you identify and fix
+KubeFleet issues you encounter. Pick one below to proceed.
+{{% /pageinfo %}}


### PR DESCRIPTION
This PR applies proper headers to some of the troubleshooting docs.