### PR TITLE
fix: ignore certain directories only if they are at the root path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,8 @@ node_modules/
 package-lock.json
 
 # Hugo outputs
-public/
-docs/
+/public/
+/docs/
 
 # Hugo pipeline stuff
-resources/
+/resources/


### PR DESCRIPTION
This PR fixes a minor issue in the `.gitignore` configuration so that certain directories will only be ignored if they are found at the root path.