### PR TITLE
docs: add TSGs for drift detection/configuration check unexpected resources and reportDiff mode failures

### DIFF
--- a/content/en/docs/troubleshooting/ClusterResourcePlacement.md
+++ b/content/en/docs/troubleshooting/ClusterResourcePlacement.md
@@ -33,11 +33,15 @@ The complete progression of `ClusterResourcePlacement` is as follows:
    - If this condition is false, refer to [CRP Override Failure TSG](ClusterResourcePlacementOverridden)
 4. `ClusterResourcePlacementWorkSynchronized`: Indicates the work objects have been synchronized.
    - If this condition is false, refer to [CRP Work-Synchronization Failure TSG](ClusterResourcePlacementWorkSynchronized)
-5. `ClusterResourcePlacementApplied`: Indicates the resource has been applied.
+5. `ClusterResourcePlacementApplied`: Indicates the resource has been applied. This condition will only be populated if the
+apply strategy in use is of the type `ClientSideApply` (default) or `ServerSideApply`.
    - If this condition is false, refer to [CRP Work-Application Failure TSG](ClusterResourcePlacementApplied)
-6. `ClusterResourcePlacementAvailable`: Indicates the resource is available. 
+6. `ClusterResourcePlacementAvailable`: Indicates the resource is available. This condition will only be populated if the
+apply strategy in use is of the type `ClientSideApply` (default) or `ServerSideApply`.
    - If this condition is false, refer to [CRP Availability Failure TSG](ClusterResourcePlacementAvailable)
-
+7. `ClusterResourcePlacementDiffreported`: Indicates whether diff reporting has completed on all resources. This condition
+will only be populated if the apply strategy in use is of the type `ReportDiff`.
+   - If this condition is false, refer to the [CRP Diff Reporting Failure TSG](ClusterResourcePlacementDiffReported) for more information.
 
 ## How can I debug if some clusters are not selected as expected?
 
@@ -55,6 +59,10 @@ Please check the following cases,
   - If `true`, verify that the resource exists on the hub cluster.
 
 We can also take a look at the `placementStatuses` section in `ClusterResourcePlacement` status for that particular cluster. In `placementStatuses` we would find `failedPlacements` section which should have the reasons as to why resources failed to apply.
+
+## How can I debug if the drift detection result or the configuration difference check result are different from my expectations?
+
+See the [Drift Detection and Configuration Difference Check Unexpected Result TSG](DriftAndDiffDetection) for more information.
 
 ## How can I find and verify the latest ClusterSchedulingPolicySnapshot for a ClusterResourcePlacement?
 

--- a/content/en/docs/troubleshooting/ClusterResourcePlacementApplied.md
+++ b/content/en/docs/troubleshooting/ClusterResourcePlacementApplied.md
@@ -5,7 +5,7 @@ weight: 6
 ---
 
 The `ClusterResourcePlacementApplied` condition is set to `false` when the deployment fails.
-> Note: To get more information about why the resources are not applied, you can check the [apply work controller](https://github.com/kubefleet-dev/kubefleet/blob/main/pkg/controllers/work/apply_controller.go) logs.
+> Note: To get more information about why the resources are not applied, you can check the [work applier](https://github.com/kubefleet-dev/kubefleet/blob/main/pkg/controllers/workapplier) logs.
 
 ## Common scenarios
 Instances where this condition may arise:

--- a/content/en/docs/troubleshooting/ClusterResourcePlacementAvailable.md
+++ b/content/en/docs/troubleshooting/ClusterResourcePlacementAvailable.md
@@ -5,7 +5,7 @@ weight: 7
 ---
 
 The `ClusterResourcePlacementAvailable` condition is `false` when some of the resources are not available yet. We will place some of the detailed failure in the `FailedResourcePlacement` array.
-> Note: To get more information about why resources are unavailable check [apply work controller](https://github.com/kubefleet-dev/kubefleet/blob/main/pkg/controllers/work/apply_controller.go) logs.
+> Note: To get more information about why resources are unavailable check [work applier](https://github.com/kubefleet-dev/kubefleet/blob/main/pkg/controllers/workapplier) logs.
 
 ## Common scenarios
 Instances where this condition may arise:

--- a/content/en/docs/troubleshooting/ClusterResourcePlacementDiffReported.md
+++ b/content/en/docs/troubleshooting/ClusterResourcePlacementDiffReported.md
@@ -1,0 +1,79 @@
+---
+title: CRP Diff Reporting Failure TSG
+description: Troubleshoot failures in the CRP diff reporting process
+weight: 8
+---
+
+This document helps you troubleshoot diff reporting failures when using the KubeFleet CRP API,
+specifically when you find that the `ClusterResourcePlacementDiffReported` status condition has been
+set to `False` in the CRP status.
+
+> Note
+>
+> If you are looking for troubleshooting steps on unexpected drift detection and/or configuration
+> difference detection results, see the [Drift Detection and Configuration Difference Detection Failure TSG](DriftAndDiffDetection)
+> instead.
+
+> Note
+>
+> The `ClusterResourcePlacementDiffReported` status condition will only be set if the CRP has
+> an apply strategy of the `ReportDiff` type. If your CRP uses `ClientSideApply` (default) or
+> `ServerSideApply` typed apply strategies, it is perfectly normal if the `ClusterResourcePlacementDiffReported`
+> status condition is absent in the CRP status.
+
+## Common scenarios
+
+`ClusterResourcePlacementDiffReported` status condition will be set to `False` if KubeFleet cannot complete
+the configuration difference checking process for one or more of the selected resources.
+
+Depending on your CRP configuration, KubeFleet might use one of the three approaches for configuration
+difference checking:
+
+* If the resource cannot be found on a member cluster, KubeFleet will simply report a full object
+difference.
+* If you ask KubeFleet to perform partial comparisons, i.e., the `comparisonOption` field in the
+CRP apply strategy (`.spec.strategy.applyStrategy.comparisonOption` field) is set to `partialComparison`,
+KubeFleet will perform a dry-run apply op (server-side apply with conflict overriding enabled) and
+compare the returned apply result against the current state of the resource on the member cluster
+side for configuration differences.
+* If you ask KubeFleet to perform full comparisons, i.e., the `comparisonOption` field in the
+CRP apply strategy (`.spec.strategy.applyStrategy.comparisonOption` field) is set to `fullComparison`,
+KubeFleet will directly compare the given manifest (the resource created on the hub cluster side) against
+the current state of the resource on the member cluster side for configuration differences.
+
+Failures might arise if:
+
+* The dry-run apply op does not complete successfully; or
+* An unexpected error occurs during the comparison process, such as a JSON path parsing/evaluation error.
+    * In this case, please consider [filing a bug to the KubeFleet team](https://github.com/kubefleet-dev/kubefleet/issues).
+
+## Investigation steps
+
+If you encounter such a failure, follow the steps below for investigation: 
+
+* Identify the specific resources that have failed in the diff reporting process first. In the CRP status,
+find out the individual member clusters that have diff reporting failures: inspect the
+`.status.placementStatuses` field of the CRP object; each entry corresponds to a member cluster, and 
+for each entry, check if it has a status condition, `ClusterResourcePlacementDiffReported`, in
+the `.status.placementStatuses[*].conditions` field, which has been set to `False`. Write down the name
+of the member cluster.
+
+* For each cluster name that has been written down, list all the work objects that have been created
+for the cluster in correspondence with the CRP object:
+
+    ```sh
+    # Replace [YOUR-CLUSTER-NAME] and [YOUR-CRP-NAME] with values of your own.
+    kubectl get work -n fleet-member-[YOUR-CLUSTER-NAME] -l kubernetes-fleet.io/parent-CRP=[YOUR-CRP-NAME]
+    ```
+
+* For each found work object, inspect its status. The `.status.manifestConditions` field features an array of which
+each item explains about the processing result of a resource on the given member cluster. Find out all items with
+a `DiffReported` condition in the `.status.manifestConditions[*].conditions` field that has been set to `False`.
+The `.status.manifestConditions[*].identifier` field tells the GVK, namespace, and name of the failing resource.
+
+* Read the `message` field of the `DiffReported` condition (`.status.manifestConditions[*].conditions[*].message`);
+KubeFleet will include the details about the diff reporting failures in the field.
+
+* If you are familiar with the cause of the error (for example, dry-run apply ops fails due to API server traffic control
+measures), fixing the cause (tweaking traffic control limits) should resolve the failure. KubeFleet will periodically
+retry diff reporting in face of failures. Otherwise, [file an issue to the KubeFleet team](https://github.com/kubefleet-dev/kubefleet/issues).

--- a/content/en/docs/troubleshooting/ClusterResourcePlacementEviction.md
+++ b/content/en/docs/troubleshooting/ClusterResourcePlacementEviction.md
@@ -1,7 +1,7 @@
 ---
 title: ClusterResourcePlacementEviction TSG
 description: Identify and fix KubeFleet issues associated with the ClusterResourcePlacementEviction API
-weight: 8
+weight: 9
 ---
 
 This guide provides troubleshooting steps for issues related to placement eviction.

--- a/content/en/docs/troubleshooting/ClusterStagedUpdateRun.md
+++ b/content/en/docs/troubleshooting/ClusterStagedUpdateRun.md
@@ -1,7 +1,7 @@
 ---
 title: ClusterStagedUpdateRun TSG
 description: Identify and fix KubeFleet issues associated with the ClusterStagedUpdateRun API
-weight: 9
+weight: 10
 ---
 
 This guide provides troubleshooting steps for common issues related to Staged Update Run.

--- a/content/en/docs/troubleshooting/DriftAndDiffDetection.md
+++ b/content/en/docs/troubleshooting/DriftAndDiffDetection.md
@@ -1,0 +1,113 @@
+---
+title: CRP Drift Detection and Configuration Difference Check Unexpected Result TSG
+description: Troubleshoot situations where CRP drift detection and configuration difference check features are returning unexpected results
+weight: 11
+---
+
+This document helps you troubleshoot unexpected drift and configuration difference
+detection results when using the KubeFleet CRP API.
+
+> Note
+>
+> If you are looking for troubleshooting steps on diff reporting failures, i.e., when
+> the `ClusterResourcePlacementDiffReported` condition on your CRP object is set to
+> `False`, see the [CRP Diff Reporting Failure TSG](ClusterResourcePlacementDiffReported)
+> instead.
+
+> Note
+>
+> This document focuses on unexpected drift and configuration difference detection
+> results. If you have encountered drift and configuration difference detection
+> failures (e.g., no detection results at all with the `ClusterResourcePlacementApplied`
+> condition being set to `False` with a detection related error), see the 
+> [CRP Apply Op Failure TSG](ClusterResourcePlacementApplied) instead.
+
+## Common scenarios
+
+A drift occurs when a non-KubeFleet agent modifies a KubeFleet-managed resource (i.e., 
+a resource that has been applied by KubeFleet). Drift details are reported in the CRP status
+on a per-cluster basis (`.status.placementStatuses[*].driftedPlacements` field).
+Drift detection is always on when your CRP uses a `ClientSideApply` (default) or
+`ServerSideApply` typed apply strategy, however, note the following limitations:
+
+* When you set the `comparisonOption` setting (`.spec.strategy.applyStrategy.comparisonOption` field)
+to `partialComparison`, KubeFleet will only detect drifts in managed fields, i.e., fields
+that have been explicitly specified on the hub cluster side. A non-KubeFleet agent can then
+add a field (e.g., a label or an annotation) to the resource without KubeFleet complaining about it.
+To check for such changes (field additions), use the `fullComparison` option for the `comparisonOption` field.
+* Depending on your cluster setup, there might exist Kubernetes webhooks/controllers (built-in or from a
+third party) that will process KubeFleet-managed resources and add/modify fields as they see fit.
+The API server on the member cluster side might also add/modify fields (e.g., enforcing default values)
+on resources. If your comparison option allows, KubeFleet will report these as drifts. For
+any unexpected drift reportings, verify first if you have installed a source that triggers the changes.
+* When you set the `whenToApply` setting (`.spec.strategy.applyStrategy.whenToApply` field)
+to `Always` and the `comparisonOption` setting (`.spec.strategy.applyStrategy.comparisonOption` field)
+to `partialComparison`, no drifts will ever be found, as apply ops from KubeFleet will
+overwrite any drift in managed fields, and drifts in unmanaged fields are always ignored.
+* Drift detection does not apply to resources that are not yet managed by KubeFleet. If a resource has
+not been created on the hub cluster or has not been selected by the CRP API, there will not be any drift
+reportings about it, even if the resource live within a KubeFleet managed namespace. Similarly, if KubeFleet
+has been blocked from taking over a pre-existing resource due to your takeover setting
+(`.spec.strategy.applyStrategy.whenToTakeOver` field), no drift detection will run on the resource.
+* Resource deletion is not considered as a drift; if a KubeFleet-managed resource has been deleted
+by a non-KubeFleet agent, KubeFleet will attempt to re-create it as soon as it finds out about the
+deletion.
+* Drift detection will not block resource rollouts. If you have just updated the resources on
+the hub cluster side and triggered a rollout, drifts on the member cluster side might have been 
+overwritten.
+* When a rollout is in progress, drifts will not be reported on the CRP status for a member cluster if
+the cluster has not received the latest round of updates.
+
+KubeFleet will check for configuration differences under the following two conditions:
+
+* When KubeFleet encounters a pre-existing resource, and the `whenToTakeOver` setting
+(`.spec.strategy.applyStrategy.whenToTakeOver` field) is set to `IfNoDiff`.
+* When the CRP uses an apply strategy of the `ReportDiff` type.
+
+Configuration difference details are reported in the CRP status
+on a per-cluster basis (`.status.placementStatuses[*].diffedPlacements` field). Note that the
+following limitations apply:
+
+* When you set the `comparisonOption` setting (`.spec.strategy.applyStrategy.comparisonOption` field)
+to `partialComparison`, KubeFleet will only check for configuration differences in managed fields,
+i.e., fields that have been explicitly specified on the hub cluster side. Unmanaged fields, such
+as additional labels and annotations, will not be considered as configuration differences.
+To check for such changes (field additions), use the `fullComparison` option for the `comparisonOption` field.
+* Depending on your cluster setup, there might exist Kubernetes webhooks/controllers (built-in or from a
+third party) that will process resources and add/modify fields as they see fit.
+The API server on the member cluster side might also add/modify fields (e.g., enforcing default values)
+on resources. If your comparison option allows, KubeFleet will report these as configuration differences.
+For any unexpected configuration difference reportings, verify first if you have installed a source that
+triggers the changes.
+* KubeFleet checks for configuration differences regardless of resource ownerships; resources not
+managed by KubeFleet will also be checked.
+* The absence of a resource will be considered as a configuration difference.
+* Configuration differences will not block resource rollouts. If you have just updated the resources on
+the hub cluster side and triggered a rollout, configuration difference check will be re-run based on the
+newer versions of resources.
+* When a rollout is in progress, configuration differences will not be reported on the CRP status
+for a member cluster if the cluster has not received the latest round of updates.
+
+Note also that drift detection and configuration difference check in KubeFleet run periodically.
+The reportings in the CRP status might not be up-to-date.
+
+## Investigation steps
+
+If you find an unexpected drift detection or configuration difference check result on a member cluster,
+follow the steps below for investigation:
+
+* Double-check the apply strategy of your CRP; confirm that your settings allows proper drift detection
+and/or configuration difference check reportings.
+* Verify that rollout has completed on all member clusters; see the [CRP Rollout Failure TSG](ClusterResourcePlacementRolloutStarted)
+for more information.
+* Log onto your member cluster and retrieve the resources with unexpected reportings.
+    * Check if its generation (`.metadata.generation` field) matches with the `observedInMemberClusterGeneration` value
+    in the drift detection and/or configuration difference check reportings. A mismatch might signal that the
+    reportings are not yet up-to-date; they should get refreshed soon.
+    * The `kubectl.kubernetes.io/last-applied-configuration` annotation and/or the `.metadata.managedFields` field might
+    have some relevant information on which agents have attempted to update/patch the resource. KubeFleet changes
+    are executed under the name `work-api-agent`; if you see other manager names, check if it comes from a known source
+    (e.g., Kubernetes controller) in your cluster.
+
+[File an issue to the KubeFleet team](https://github.com/kubefleet-dev/kubefleet/issues) if you believe that
+the unexpected reportings come from a bug in KubeFleet.


### PR DESCRIPTION
This PR adds new TSGs for drift detection + configuration difference check unexpected results and reportDiff mode failures.

Note: takeover failures are part of the apply failures, which falls under the umbrella of apply failures TSGs -> this one might need a rewrite; will send a separate PR.