### PR TITLE
feat: auto-add CNAME file to the built artifacts

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -40,6 +40,9 @@ jobs:
 
       - name: Build
         run: hugo --minify
+      
+      - name: Add CNAME file
+        run: echo 'kubefleet.dev' > ./public/CNAME
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This PR adds a CNAME file to the built artifacts so that GH pages would recognize the new domain automatically.