### PR TITLE
docs: update resource placement concept doc to use namespace only CRP

### DIFF
--- a/content/en/docs/concepts/rp.md
+++ b/content/en/docs/concepts/rp.md
@@ -116,6 +116,7 @@ spec:
       kind: Namespace
       name: my-app
       version: v1
+      selectionScope: NamespaceOnly # only namespace itself is placed, no resources within the namespace
   policy:
     placementType: PickAll
 ---


### PR DESCRIPTION
update resource placement concept doc to use namespace only CRP

this is consistent with our example https://github.com/kubefleet-dev/kubefleet/blob/main/examples/resourceplacement/test-crp.yaml

Otherwise whatever is in that namespace will get deployed to all clusters anyway, making the fine-grained control of RP not useful