### PR TITLE
docs: Adapt quickstart and how-tos to new release v0.3.1 for TLS between member and hub

### DIFF
--- a/content/en/docs/getting-started/kind.md
+++ b/content/en/docs/getting-started/kind.md
@@ -99,7 +99,7 @@ Record the IP address that's returned.
 
 ### Select KubeFleet version
 
-Next, select the KubeFleet version to run by looking at the [KubeFleet GitHub Releases page](https://github.com/kubefleet-dev/kubefleet/releases) and picking a version - for example 0.3.0.
+Next, select the KubeFleet version to run by looking at the [KubeFleet GitHub Releases page](https://github.com/kubefleet-dev/kubefleet/releases) and picking a version - for example 0.3.1.
 
 > Note: we recommend using the most recent KubeFleet release for the best experience.
 
@@ -115,7 +115,7 @@ Use helm to install the hub agent on the cluster. The following command provides
 
 ```sh
 helm upgrade --install hub-agent oci://ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent \
-    --version 0.3.0 \
+    --version 0.3.1 \
     --namespace fleet-system \
     --create-namespace \
     --set logFileMaxSize=100000
@@ -124,7 +124,7 @@ helm upgrade --install hub-agent oci://ghcr.io/kubefleet-dev/kubefleet/charts/hu
 It will take a few seconds for the installation to complete. Output looks similar to the following.
 
 ```output
-Pulled: ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent:0.3.0
+Pulled: ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent:0.3.1
 Digest: sha256:xxxxxx
 NAME: hub-agent
 LAST DEPLOYED: Tue Mar 24 11:14:03 2026
@@ -162,7 +162,7 @@ To use this script successfully make sure:
 
 * You know the hub and member cluster names.
 * Your kubeconfig includes all clusters. This includes the hub and all members you want to join.
-* You have the KubeFleet version to deploy (i.e. 0.3.0)
+* You have the KubeFleet version to deploy (i.e. 0.3.1)
 * You have the IP address of the hub cluster (i.e. 172.18.0.2)
 
 Unless you made any modifications, the hub cluster's API server will listen on port 6443.
@@ -170,13 +170,13 @@ Unless you made any modifications, the hub cluster's API server will listen on p
 On MacOSX or Linux you can use this shell script:
 
 ```sh
-./join-member-clusters.sh 0.3.0 kind-kf-hub-01 https://172.18.0.2:6443/ kind-kf-member-01
+./join-member-clusters.sh 0.3.1 kind-kf-hub-01 https://172.18.0.2:6443/ kind-kf-member-01
 ```
 
 On Windows you can use PowerShell:
 
 ```powershell
-.\join-member-clusters.ps1 0.3.0 kind-kf-hub-01 https://172.18.0.2:6443/ kind-kf-member-01
+.\join-member-clusters.ps1 0.3.1 kind-kf-hub-01 https://172.18.0.2:6443/ kind-kf-member-01
 ```
 
 > Note: you can add multiple member clusters to join by adding them on the end of the argument list.

--- a/content/en/docs/how-tos/clusters.md
+++ b/content/en/docs/how-tos/clusters.md
@@ -171,6 +171,11 @@ Fleet connection:
     # Replace the value of HUB_CLUSTER_ADDRESS with the address of the hub cluster API server.
     export HUB_CLUSTER_ADDRESS="YOUR-HUB-CLUSTER-ADDRESS"
 
+    # Extract the hub cluster CA for secure TLS verification.
+    # Run this while connected to the hub cluster context:
+    #   kubectl config view --raw -o jsonpath='{.clusters[?(@.name=="YOUR-HUB-CLUSTER")].cluster.certificate-authority-data}'
+    export HUB_CA="YOUR-HUB-CLUSTER-CA-BASE64"
+
     # The variables below uses the Fleet images kept in the Microsoft Container
     # Registry (MCR) and will retrieve the latest version from the Fleet GitHub
     # repository. This pulls from the Azure Fleet repository while the kubefleet
@@ -188,6 +193,7 @@ Fleet connection:
     kubectl create secret generic hub-kubeconfig-secret --from-literal=token=$TOKEN
     helm install member-agent kubefleet/charts/member-agent/ \
         --set config.hubURL=$HUB_CLUSTER_ADDRESS \
+        --set config.hubCA=$HUB_CA \
         --set image.repository=$REGISTRY/$MEMBER_AGENT_IMAGE \
         --set image.tag=$FLEET_VERSION \
         --set refreshtoken.repository=$REGISTRY/$REFRESH_TOKEN_IMAGE \

--- a/content/en/docs/how-tos/clusters.md
+++ b/content/en/docs/how-tos/clusters.md
@@ -173,8 +173,7 @@ Fleet connection:
 
     # Extract the hub cluster CA for secure TLS verification.
     # Run this while connected to the hub cluster context:
-    #   kubectl config view --raw -o jsonpath='{.clusters[?(@.name=="YOUR-HUB-CLUSTER")].cluster.certificate-authority-data}'
-    export HUB_CA="YOUR-HUB-CLUSTER-CA-BASE64"
+    export HUB_CA=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name==\"$HUB_CLUSTER_CONTEXT\")].cluster.certificate-authority-data}")
 
     # The variables below uses the Fleet images kept in the Microsoft Container
     # Registry (MCR) and will retrieve the latest version from the Fleet GitHub


### PR DESCRIPTION
Adapt quickstart and how-tos to new release v0.3.1 for TLS between member and hub

For this release: https://github.com/kubefleet-dev/kubefleet/releases/tag/v0.3.1