### PR TITLE
ci: bump Node.js from 18 to 24

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Install dependencies from NPM
         run: npm install


### PR DESCRIPTION
## Summary

- Bump `node-version` in `.github/workflows/github-pages.yml` from `'18'` to `'24'`.

Node.js 18 reached EOL on 2025-04-30 and Node.js 20 reached EOL on 2026-04-30. Node.js 24 is the current active LTS (since 2025-10).

The dev dependencies in `package.json` (`autoprefixer`, `postcss-cli`) work on both Node 22 and 24.

Closes #108.

## Test plan

- [x] CI runs `npm install` on Node 24 and `hugo --minify` succeeds.
