### PR TITLE
docs: refresh stale Kubernetes version references

### DIFF
--- a/configs/api-refs-generator.yaml
+++ b/configs/api-refs-generator.yaml
@@ -10,6 +10,6 @@ processor:
 
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: 1.31
+  kubernetesVersion: 1.34
   # Generate better link for known types
   knownTypes:

--- a/content/en/docs/getting-started/kind.md
+++ b/content/en/docs/getting-started/kind.md
@@ -55,7 +55,7 @@ The output will look similar to the following.
 
 ```output
 Creating cluster "kf-hub-01" ...
- ✓ Ensuring node image (kindest/node:v1.35.0) 🖼
+ ✓ Ensuring node image (kindest/node:v1.32.8) 🖼
  ✓ Preparing nodes 📦
  ✓ Writing configuration 📜
  ✓ Starting control-plane 🕹️

--- a/content/en/docs/how-tos/clusters.md
+++ b/content/en/docs/how-tos/clusters.md
@@ -14,8 +14,7 @@ This how-to guide discusses how to manage clusters in a fleet, specifically:
 
 A cluster can join in a fleet if:
 
-* it runs a supported Kubernetes version; it is recommended that you use Kubernetes 1.24 or later
-versions, and
+* it runs a [currently supported Kubernetes version](https://kubernetes.io/releases/version-skew-policy/) — KubeFleet builds against `client-go` v0.34 (Kubernetes 1.31 or later under the standard skew policy) and CI tests against Kubernetes 1.33; and
 * it has network connectivity to the hub cluster of the fleet.
 
 For your convenience, Fleet provides a script that can automate the process of joining a cluster


### PR DESCRIPTION
## Summary

Three stale Kubernetes-version references refreshed:

- `configs/api-refs-generator.yaml`: `kubernetesVersion: 1.31` → `1.34`. This is what `crd-ref-docs` uses to link API field types into the upstream Kubernetes docs. 1.31 reached EOL in October 2025; 1.34 matches the `k8s.io/*` v0.34.1 dependencies in upstream kubefleet's `go.mod`.
- `content/en/docs/how-tos/clusters.md` line 17: replaced "Kubernetes 1.24 or later" (EOL July 2023) with a statement that combines (1) a pointer to the upstream Kubernetes [version-skew policy](https://kubernetes.io/releases/version-skew-policy/), (2) the client-go skew (KubeFleet builds against client-go v0.34, supporting Kubernetes 1.31+), and (3) the actual CI-tested version (1.33, per `kubefleet/Makefile`'s `KIND_IMAGE`).
- `content/en/docs/getting-started/kind.md` line 58: `kindest/node:v1.35.0` → `v1.32.8`. The 1.35.0 tag does not exist; 1.32.8 matches the example already shown on line 44.

The wording in clusters.md is intentionally not a hard "minimum supported version" claim — kubefleet does not state one anywhere in its source. If a future release introduces an explicit minimum, this line should be tightened.

Closes #109.

## Test plan

- [ ] CI builds the site successfully.
- [ ] The next scheduled `update-api-refs` run regenerates `content/en/docs/api-reference/` against `kubernetesVersion: 1.34` without churn beyond intended K8s-link updates.
