### PR TITLE
ci: bump pinned GitHub Actions to current majors

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo 'kubefleet.dev' > ./public/CNAME
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         # Skip this step if it is triggered by a PR.
         if: github.ref == 'refs/heads/main'
         with:

--- a/.github/workflows/update-api-refs.yaml
+++ b/.github/workflows/update-api-refs.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.git-check.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |


### PR DESCRIPTION
## Summary

Two pinned GitHub Actions are two majors behind:

- `peter-evans/create-pull-request@v6` → `@v8` in `.github/workflows/update-api-refs.yaml`.
- `peaceiris/actions-gh-pages@v3` → `@v4` in `.github/workflows/github-pages.yml`.

`peaceiris/actions-hugo@v3` is left as-is — `v3` is still the current major.

Closes #110.

## Test plan

- [ ] `github-pages.yml` runs on this PR (build-only, no deploy) and stays green.
- [ ] After merge, the next push to `main` exercises `peaceiris/actions-gh-pages@v4` end-to-end.
- [ ] The next scheduled `update-api-refs` cron (or a manual `workflow_dispatch`) verifies `peter-evans/create-pull-request@v8` works.
