### PR TITLE
ci: bump Hugo from 0.145.0 to 0.161.1

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.145.0'
+          hugo-version: '0.161.1'
           extended: true
 
       - name: Setup Node.js

--- a/hugo.toml
+++ b/hugo.toml
@@ -57,7 +57,7 @@ anchor = "Smart"
 
 [languages]
 [languages.en]
-languageName ="English"
+label ="English"
 # Weight used for sorting.
 weight = 1
 [languages.en.params]


### PR DESCRIPTION
## Summary

- Bump pinned Hugo from `0.145.0` to `0.161.1` in `.github/workflows/github-pages.yml`.
- Rename deprecated `languages.en.languageName` to `languages.en.label` in `hugo.toml` (deprecated in Hugo 0.158.0).

The `languageName` rename is bundled because Hugo 0.161.1 surfaces it as a deprecation warning on every build. With #113 (Node 24) now merged, the PostCSS permission flags Hugo ≥ 0.158 needs are available on the CI runner.

Verified locally with Hugo 0.161.1 + Node 22: `hugo --minify` succeeds with no errors and no warnings.

The submodule SHA refresh from #111 is intentionally left for a separate PR — that needs visual diff review against the rendered Docsy theme.

Closes #111 partially.

## Test plan

- [x] Local: `git submodule update --init && npm install && hugo --minify` succeeds with Hugo 0.161.1 on Node 22.
- [x] CI on this PR: `peaceiris/actions-hugo@v3` installs 0.161.1 against Node 24, `npm install` and `hugo --minify` succeed (build-and-deploy passed in 46s; 88 pages built in 2702ms).
