### PR TITLE
ci: pin crd-ref-docs to v0.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: ## Display this help message
 .PHONY: install-tools
 install-tools: ## Install required tools (crd-ref-docs)
 	@echo "Installing crd-ref-docs..."
-	go install github.com/elastic/crd-ref-docs@latest
+	go install github.com/elastic/crd-ref-docs@v0.3.0
 
 .PHONY: clone-kubefleet
 clone-kubefleet: ## Clone KubeFleet source repository


### PR DESCRIPTION
## Summary

`Makefile` line 16 currently runs:

```
go install github.com/elastic/crd-ref-docs@latest
```

`@latest` means the daily `update-api-refs` GitHub Action installs whatever release is current at run time, so generated API-reference formatting can change without a tracked cause. Pin to `@v0.3.0` (current latest at time of PR) and bump deliberately in future.

Closes #112.

## Test plan

- [ ] `make install-tools` followed by `make update-api-refs` produces the same output as the latest scheduled `update-api-refs` run.
- [ ] The next scheduled cron PR (or a manual `workflow_dispatch`) installs `crd-ref-docs@v0.3.0` and regenerates without unintended diff.
