### PR TITLE
docs: batch one-line typo and syntax fixes

### DIFF
--- a/content/en/docs/getting-started/kind.md
+++ b/content/en/docs/getting-started/kind.md
@@ -288,7 +288,7 @@ To remove all the resources you just created, run the commands below:
 kubectl delete crp sample-crp
 
 kubectl delete ns kubefleet-sample
-kubectl delete configmap app -n kubefleet-sample
+kubectl delete configmap kf-cm -n kubefleet-sample
 ```
 
 To uninstall KubeFleet components on the clusters, run the commands below:

--- a/content/en/docs/getting-started/on-prem.md
+++ b/content/en/docs/getting-started/on-prem.md
@@ -189,6 +189,9 @@ the completion.
 Now, log into the member clusters to confirm that the placement has been completed.
 
 ```sh
+# Replace YOUR-MEMBER-CLUSTER-CONTEXT with the name of the kubeconfig context for one of
+# the member clusters you joined above.
+export MEMBER_CLUSTER_CONTEXT=YOUR-MEMBER-CLUSTER-CONTEXT
 kubectl config use-context $MEMBER_CLUSTER_CONTEXT
 kubectl get ns
 kubectl get configmap -n work

--- a/content/en/docs/how-tos/affinities.md
+++ b/content/en/docs/how-tos/affinities.md
@@ -80,9 +80,9 @@ includes:
   * `In`: the cluster must have a label key with one of the listed values.
   * `NotIn`: the cluster must have a label key that is not associated with any of the listed values.
   * `Exists`: the cluster must have the label key present; any value is acceptable.
-  * `NotExists`: the cluster must not have the label key.
+  * `DoesNotExist`: the cluster must not have the label key.
 
-    If you plan to use `Exists` and/or `NotExists`, you must leave the list of values empty.
+    If you plan to use `Exists` and/or `DoesNotExist`, you must leave the list of values empty.
 
 Below is an example of `matchExpressions` affinity term using the `In` operator:
 

--- a/content/en/docs/how-tos/crp.md
+++ b/content/en/docs/how-tos/crp.md
@@ -266,9 +266,9 @@ spec:
             preferredDuringSchedulingIgnoredDuringExecution:
                 - weight: 20
                   preference:
-                    - labelSelector:
-                        matchLabels:
-                            critical-level: 1
+                      labelSelector:
+                          matchLabels:
+                              critical-level: "1"
 ```
 
 The `ClusterResourcePlacement` object above will pick first clusters with the `critical-level=1`


### PR DESCRIPTION
## Summary

Bundled small doc fixes — each one is a one- or two-line change against a different file:

- **#103** — `affinities.md`: prose said `NotExists`; the correct `LabelSelectorRequirement` operator is `DoesNotExist`. The YAML example on the same page already uses `DoesNotExist`, so this just makes the prose match.
- **#102** — `crp.md`: PickN affinity example had `preference:` as a list (`- labelSelector:`); `preference` is a single `ClusterSelectorTerm`, not a slice. Also quoted the `critical-level: \"1\"` value to match the label-as-string contract.
- **#98** — `kind.md`: cleanup said `kubectl delete configmap app -n kubefleet-sample` but the create step uses `kf-cm`. Renamed the cleanup to `kf-cm`.
- **#95** — `on-prem.md`: the script-based path used `\$MEMBER_CLUSTER_CONTEXT` without ever setting it. Added an `export MEMBER_CLUSTER_CONTEXT=YOUR-MEMBER-CLUSTER-CONTEXT` instruction before the first usage, mirroring how `HUB_CLUSTER_CONTEXT` is introduced near the top of the doc.

Closes #103.
Closes #102.
Closes #98.
Closes #95.

## Test plan

- [x] Local: \`hugo --minify\` succeeds with no errors or warnings.
- [ ] CI \`build-and-deploy\` passes on this PR.